### PR TITLE
Fix for new timezone name

### DIFF
--- a/iocAdmin/Db/iocAdminRTEMS.substitutions
+++ b/iocAdmin/Db/iocAdminRTEMS.substitutions
@@ -37,7 +37,8 @@ pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}
 	{ $(IOC) , CA_MAX_ARRAY , EPICS_CA_MAX_ARRAY_BYTES        , epics  }
 	{ $(IOC) , CA_SRCH_TIME , EPICS_CA_MAX_SEARCH_PERIOD      , epics  }
 	{ $(IOC) , CA_BEAC_TIME , EPICS_CA_BEACON_PERIOD          , epics  }
-	{ $(IOC) , TIMEZONE     , EPICS_TIMEZONE                  , epics  }
+	{ $(IOC) , TIMEZONE     , EPICS_TZ                        , epics  }
+	{ $(IOC) , TZ           , EPICS_TZ                        , epics  }
 	{ $(IOC) , TS_NTP_INET  , EPICS_TS_NTP_INET               , epics  }
 	{ $(IOC) , IOC_LOG_PORT , EPICS_IOC_LOG_PORT              , epics  }
 	{ $(IOC) , IOC_LOG_INET , EPICS_IOC_LOG_INET              , epics  }

--- a/iocAdmin/Db/iocAdminSoft.substitutions
+++ b/iocAdmin/Db/iocAdminSoft.substitutions
@@ -27,7 +27,8 @@ pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}
 	{ $(IOC) , CA_MAX_ARRAY , EPICS_CA_MAX_ARRAY_BYTES        , epics  }
 	{ $(IOC) , CA_SRCH_TIME , EPICS_CA_MAX_SEARCH_PERIOD      , epics  }
 	{ $(IOC) , CA_BEAC_TIME , EPICS_CA_BEACON_PERIOD          , epics  }
-	{ $(IOC) , TIMEZONE     , EPICS_TIMEZONE                  , epics  }
+	{ $(IOC) , TIMEZONE     , EPICS_TZ                        , epics  }
+	{ $(IOC) , TZ           , EPICS_TZ                        , epics  }
 	{ $(IOC) , TS_NTP_INET  , EPICS_TS_NTP_INET               , epics  }
 	{ $(IOC) , IOC_LOG_PORT , EPICS_IOC_LOG_PORT              , epics  }
 	{ $(IOC) , IOC_LOG_INET , EPICS_IOC_LOG_INET              , epics  }

--- a/iocAdmin/Db/iocAdminVxWorks.substitutions
+++ b/iocAdmin/Db/iocAdminVxWorks.substitutions
@@ -37,7 +37,8 @@ pattern { IOCNAME, ENVNAME      , ENVVAR                          , ENVTYPE}
 	{ $(IOC) , CA_MAX_ARRAY , EPICS_CA_MAX_ARRAY_BYTES        , epics  }
 	{ $(IOC) , CA_SRCH_TIME , EPICS_CA_MAX_SEARCH_PERIOD      , epics  }
 	{ $(IOC) , CA_BEAC_TIME , EPICS_CA_BEACON_PERIOD          , epics  }
-	{ $(IOC) , TIMEZONE     , EPICS_TIMEZONE                  , epics  }
+	{ $(IOC) , TIMEZONE     , EPICS_TZ                        , epics  }
+	{ $(IOC) , TZ           , EPICS_TZ                        , epics  }
 	{ $(IOC) , TS_NTP_INET  , EPICS_TS_NTP_INET               , epics  }
 	{ $(IOC) , IOC_LOG_PORT , EPICS_IOC_LOG_PORT              , epics  }
 	{ $(IOC) , IOC_LOG_INET , EPICS_IOC_LOG_INET              , epics  }


### PR DESCRIPTION
EPICS_TIMEZONE has become EPICS_TZ in EPICS7

See ISISComputingGroup/IBEX#4983
